### PR TITLE
ensure that param is matches before replace

### DIFF
--- a/__tests__/to-sql.test.ts
+++ b/__tests__/to-sql.test.ts
@@ -12,4 +12,16 @@ describe('toSQL - Function', () => {
     expect(sql).toEqual(expectedSQL)
     expect(arrParams).toEqual(expectedArr)
   })
+  
+  it('should not add param to query when it was not found', () => {
+    const expectedSQL = "SELECT * FROM table WHERE name = $1"
+    const expectedArr = ['xstarman']
+    const query = "SELECT * FROM table WHERE name = :name"
+    const params = { name: 'xstarman', teste: 'not-found' }
+
+    const [sql, arrParams] = toSQL<{ name: string }>(query, params)
+
+    expect(sql).toEqual(expectedSQL)
+    expect(arrParams).toEqual(expectedArr)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,8 +69,10 @@ export const toSQL = <T extends object = any>(sql: string, parameters: T): [stri
   for(const [key, value] of entries) {
       const parameter = createParameterKey(key)
       const regex = new RegExp(parameter, 'g')
+      
+      if (!newSql.match(regex)) continue
+   
       const reference = createReference(refIndex)
-
       newSql = newSql.replace(regex, reference)
 
       arrParams.push(value)


### PR DESCRIPTION
Using same regex to ensure that param is present before replacing. With this we dont have missing parameters when string is not found.